### PR TITLE
This avoids crashes with empty data sets

### DIFF
--- a/tw2/forms/datagrid.py
+++ b/tw2/forms/datagrid.py
@@ -117,7 +117,7 @@ class DataGrid(twc.Widget):
     def prepare(self):
         super(DataGrid, self).prepare()
 
-        if not self.value:
+        if self.value is None:
             raise ValueError(
                 "DataGrid must be passed a value.")
 


### PR DESCRIPTION
This change is required to avoid DataGrid crashing when an empty set of data is passed, as otherwise due to **len** returning 0 causes value to evaluate at False which causes ValueError exception to be raised
