### PR TITLE
Fix required keyword for Calendar*Pickers

### DIFF
--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,4 +1,5 @@
 from tw2.forms.widgets import *
+from tw2.forms.calendars import *
 from webob import Request
 from webob.multidict import NestedMultiDict
 from tw2.core.testbase import (
@@ -12,6 +13,7 @@ from tw2.core import EmptyField, IntValidator, ValidationError
 from cgi import FieldStorage
 import formencode
 import formencode.national
+from datetime import datetime
 
 import webob
 if hasattr(webob, 'NestedMultiDict'):
@@ -851,3 +853,38 @@ class TestFormPage(WidgetTest):
             r.body == """Form posted successfully {'field2': 'b', 'field3': 'c', 'field1': 'a'}""" or
             r.body == """Form posted successfully {'field2': u'b', 'field3': u'c', 'field1': u'a'}"""
             ), r.body
+
+
+def test_picker_validation():
+    """ Test that CalendarDate*Pickers validate correctly. """
+
+    class SomeForm(TableForm):
+        date = CalendarDatePicker(date_format='%Y-%m-%d')
+        datetime = CalendarDateTimePicker(date_format='%Y-%m-%d %H:%M')
+
+    data = SomeForm.validate({'date': '2012-06-13', 'datetime': '2012-06-13 10:07'})
+    for field in data.itervalues():
+        assert isinstance(field, datetime)
+
+
+def test_picker_required_validation():
+    """ Test that CalendarDate*Pickers validate required fields correctly. """
+
+    class SomeForm(TableForm):
+        date = CalendarDatePicker(date_format='%Y-%m-%d', required=True)
+        datetime = CalendarDateTimePicker(date_format='%Y-%m-%d %H:%M', required=True)
+
+    try:
+        data = SomeForm.validate({'date': '', 'datetime': '2012-06-13 10:07'})
+    except ValidationError:
+        pass
+    else:
+        assert False
+
+    try:
+        data = SomeForm.validate({'date': '2012-06-13', 'datetime': ''})
+    except ValidationError:
+        pass
+    else:
+        assert False
+

--- a/tw2/forms/calendars.py
+++ b/tw2/forms/calendars.py
@@ -121,7 +121,7 @@ class CalendarDatePicker(FormField):
     template = "tw2.forms.templates.calendar"
     calendar_lang = twc.Param("Default Language to use in the Calendar",
                               default='en')
-    not_empty = twc.Param("Allow this field to be empty", default=True)
+    required = twc.Param(default=False)
     button_text = twc.Param("Text to display on Button", default="Choose")
     date_format = twc.Param("Date Display Format", default="%m/%d/%Y")
     picker_shows_time = twc.Param('Picker Shows Time', default=False)
@@ -147,13 +147,14 @@ class CalendarDatePicker(FormField):
         if self.validator is None:
             self.validator = twc.DateTimeValidator(
             format=self.date_format,
+            required=self.required
             )
         super(CalendarDatePicker, self).__init__(*args, **kw)
 
     def prepare(self):
         super(CalendarDatePicker, self).prepare()
         self.resources = [calendar_css, calendar_js, calendar_setup]
-        if not self.value:
+        if not self.value and self.required:
             if callable(self.default):
                 self.value = self.default()
             else:

--- a/tw2/forms/widgets.py
+++ b/tw2/forms/widgets.py
@@ -19,8 +19,7 @@ class FormField(twc.Widget):
     @property
     def required(self):
         return self.validator and (
-            getattr(self.validator, 'required', None) or
-            getattr(self.validator, 'not_empty', None)
+            getattr(self.validator, 'required', None)
         )
 
 


### PR DESCRIPTION
Fixes Issue #8!

Corresponds to the tw2.core patch for the validators:  https://github.com/toscawidgets/tw2.core/pull/31
