### PR TITLE
Make twf.Label validate to twc.EmptyField

### DIFF
--- a/tw2/forms/widgets.py
+++ b/tw2/forms/widgets.py
@@ -638,6 +638,9 @@ class Label(twc.Widget):
     label = None
     id = None
 
+    def _validate(self, value, state=None):
+        return twc.EmptyField
+
 
 class Form(twc.DisplayOnlyWidget):
     """


### PR DESCRIPTION
Just the same as twf.Space.
Otherwise, the validates results will include a None key which makes
e.g. TurboGears2 choke if the dict is passed as method kwargs:
`TypeError: post() keywords must be strings`
