### PR TITLE
Corrected typo that prevented Calendar widget of being rendered.

### DIFF
--- a/tw2/forms/templates/calendar.jinja
+++ b/tw2/forms/templates/calendar.jinja
@@ -4,7 +4,7 @@
   <script type="text/javascript">Calendar.setup({
     "inputField": "{{ w.compound_id }}", "showsTime": {{ w.picker_shows_time | lower }},
     "ifFormat": "{{ w.date_format }}", "button": "{{ w.compound_id }}_trigger"
-    {% for k, v in w.setup_options.items %}
+    {% for k, v in w.setup_options.items() %}
     , {{ k }}: {{ isinstance(v, twc.JSSymbol) and (v.src) or '"%s"' % v }}
     {% endfor %}
   })</script>


### PR DESCRIPTION
When working on Jinja templates a small typo got in, this prevented Calendar widget from being rendered, the problem was that getting the widget setup_option.items was not called as a function.
