### PR TITLE
Enable usage of html in Label

### DIFF
--- a/tw2/forms/templates/label.mak
+++ b/tw2/forms/templates/label.mak
@@ -1,2 +1,8 @@
 <%namespace name="tw" module="tw2.core.mako_util"/>\
-<span ${tw.attrs(attrs=w.attrs)}>${w.text}</span>
+<span ${tw.attrs(attrs=w.attrs)}>
+% if w.escape:
+  ${w.text}
+% else:
+  ${w.text | n}
+% endif
+</span>

--- a/tw2/forms/widgets.py
+++ b/tw2/forms/widgets.py
@@ -635,6 +635,7 @@ class Label(twc.Widget):
     """
     template = 'tw2.forms.templates.label'
     text = twc.Param('Text to appear in label')
+    escape = twc.Param('Whether text shall be html-escaped or not', default=True)
     label = None
     id = None
 


### PR DESCRIPTION
In some cases, I'd like to be able to put plain HTML in a `Label`, so I thought we could implement that quite quickly!

I could only do the Mako template, the other two templates need to be edited accordingly, too!
