### PR TITLE
Fix escape for Label with jinja template

### DIFF
--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -653,6 +653,19 @@ class TestLabel(WidgetTest):
     attrs = {'text': 'something'}
     expected = """<span>something</span>"""
 
+    def test_escape(self):
+        attrs = {'text': 'line 1<br />line 2'}
+        expected = '<span>line 1&lt;br /&gt;line 2</span>'
+        for engine in self._get_all_possible_engines():
+            yield (self._check_rendering_vs_expected,
+                engine, attrs, self.params, expected)
+
+        attrs = {'text': 'line 1<br />line 2', 'escape': False}
+        expected = '<span>line 1<br />line 2</span>'
+        for engine in self._get_all_possible_engines():
+            yield (self._check_rendering_vs_expected,
+                engine, attrs, self.params, expected)
+
 
 class TestForm(WidgetTest):
 

--- a/tw2/forms/templates/label.jinja
+++ b/tw2/forms/templates/label.jinja
@@ -1,1 +1,1 @@
-<span {{ w.attrs|xmlattr }}>{{ w.text }}</span>
+<span {{ w.attrs|xmlattr }}>{% if w.escape %}{{ w.text|string }}{% else %}{{ w.text|safe }}{% endif %}</span>


### PR DESCRIPTION
Sorry I didn't see this before but the Label jinja template was not coded correctly!
