### PR TITLE
Correct _opt_matches_value in MultiSelectionField

### DIFF
--- a/tw2/forms/widgets.py
+++ b/tw2/forms/widgets.py
@@ -275,6 +275,8 @@ class HTML5PatternMixin(twc.Widget):
     '''
     pattern = twc.Param('JavaScript regex to match field with',
         attribute=True, default=None)
+    title = twc.Param('Tooltip and message shown on invalid value',
+        attribute=True, default=None)
 
 
 class HTML5MinMaxMixin(twc.Widget):


### PR DESCRIPTION
As mentioned in https://github.com/toscawidgets/tw2.core/issues/102 this makes sure that the value and opt are of the same type when using a formencode validator
