### PR TITLE
Add the title attribute to HTML5PatternMixin

### DIFF
--- a/tw2/forms/widgets.py
+++ b/tw2/forms/widgets.py
@@ -275,6 +275,8 @@ class HTML5PatternMixin(twc.Widget):
     '''
     pattern = twc.Param('JavaScript regex to match field with',
         attribute=True, default=None)
+    title = twc.Param('Tooltip and message shown on invalid value',
+        attribute=True, default=None)
 
 
 class HTML5MinMaxMixin(twc.Widget):


### PR DESCRIPTION
The title attribute results in a tooltip on hoover and an explanation on invalid
values. as explained in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-pattern :

> Use the title attribute to describe the pattern to help the user
