### PR TITLE
Let TextArea (SelectionField, calendars) have required, autofocus HTML5 attributes.

### DIFF
--- a/tw2/forms/calendars.py
+++ b/tw2/forms/calendars.py
@@ -37,7 +37,7 @@ import time
 import logging
 
 import tw2.core as twc
-from .widgets import FormField
+from .widgets import RequiredAttrMixin, FormField
 
 
 __all__ = [
@@ -129,7 +129,8 @@ calendar_langs = dict(
 )
 
 
-class CalendarDatePicker(FormField, CalendarBase):
+class CalendarDatePicker(
+        RequiredAttrMixin, FormField, CalendarBase):
     """
     Uses a javascript calendar system to allow picking of calendar dates.
     The date_format is in yyyy-mm-dd unless otherwise specified
@@ -137,7 +138,6 @@ class CalendarDatePicker(FormField, CalendarBase):
     template = "tw2.forms.templates.calendar"
     calendar_lang = twc.Param("Default Language to use in the Calendar",
                               default='en')
-    required = twc.Param(default=False)
     button_text = twc.Param("Text to display on Button", default="Choose")
     date_format = twc.Param("Date Display Format", default="%Y-%m-%d")
     picker_shows_time = twc.Param('Picker Shows Time', default=False)

--- a/tw2/forms/calendars.py
+++ b/tw2/forms/calendars.py
@@ -37,7 +37,7 @@ import time
 import logging
 
 import tw2.core as twc
-from .widgets import RequiredAttrMixin, FormField
+from .widgets import RequiredAttrMixin, AutofocusAttrMixin, FormField
 
 
 __all__ = [
@@ -130,7 +130,7 @@ calendar_langs = dict(
 
 
 class CalendarDatePicker(
-        RequiredAttrMixin, FormField, CalendarBase):
+        RequiredAttrMixin, AutofocusAttrMixin, FormField, CalendarBase):
     """
     Uses a javascript calendar system to allow picking of calendar dates.
     The date_format is in yyyy-mm-dd unless otherwise specified

--- a/tw2/forms/widgets.py
+++ b/tw2/forms/widgets.py
@@ -24,6 +24,26 @@ class FormField(twc.Widget):
         )
 
 
+class RequiredAttrMixin(twc.Widget):
+
+    required = twc.Param('Form field is required',
+        attribute=True, default=None)
+
+    def prepare(self):
+        super(RequiredAttrMixin, self).prepare()
+        self.safe_modify('attrs')
+        self.attrs['required'] = 'required' if self.required in [
+                True, 'required'] else None
+        # Needed because self.required would otherwise overwrite
+        # self.attrs['required'] again
+        self.required = None
+
+
+class AutofocusAttrMixin(twc.Widget):
+    autofocus = twc.Param('Autofocus form field (HTML5 only)',
+        attribute=True, default=None)
+
+
 class TextFieldMixin(twc.Widget):
     '''Misc mixin class with attributes for textual input fields'''
     maxlength = twc.Param('Maximum length of field',
@@ -32,26 +52,14 @@ class TextFieldMixin(twc.Widget):
         attribute=True, default=None)
 
 
-class InputField(FormField):
+class InputField(RequiredAttrMixin, AutofocusAttrMixin, FormField):
     type = twc.Variable('Type of input field',
                         default=twc.Required,
                         attribute=True)
 
     value = twc.Param(attribute=True)
 
-    required = twc.Param('Input field is required',
-        attribute=True, default=None)
-
-    autofocus = twc.Param('Autofocus form field (HTML5 only)',
-        attribute=True, default=None)
-
     template = "tw2.forms.templates.input_field"
-
-    def prepare(self):
-        super(InputField, self).prepare()
-        self.safe_modify('attrs')
-        self.attrs['required'] = 'required' if self.required in [True, 'required'] else None
-        self.required = None  # Needed because self.required would otherwise overwrite self.attrs['required'] again
 
 
 class PostlabeledInputField(InputField):

--- a/tw2/forms/widgets.py
+++ b/tw2/forms/widgets.py
@@ -76,7 +76,8 @@ class TextField(TextFieldMixin, InputField):
     type = 'text'
 
 
-class TextArea(TextFieldMixin, FormField):
+class TextArea(
+        TextFieldMixin, RequiredAttrMixin, AutofocusAttrMixin, FormField):
     rows = twc.Param('Number of rows', default=None, attribute=True)
     cols = twc.Param('Number of columns', default=None, attribute=True)
     template = "tw2.forms.templates.textarea"
@@ -372,7 +373,7 @@ class ColorField(TextField):
 #--
 # Selection fields
 #--
-class SelectionField(FormField):
+class SelectionField(RequiredAttrMixin, AutofocusAttrMixin, FormField):
     """
     Base class for single and multiple selection fields.
 

--- a/tw2/forms/widgets.py
+++ b/tw2/forms/widgets.py
@@ -45,7 +45,7 @@ class AutofocusAttrMixin(twc.Widget):
 
 
 class TextFieldMixin(twc.Widget):
-    '''Misc mixin class with attributes for textual input fields'''
+    '''Misc mixin class with attributes for textual form fields'''
     maxlength = twc.Param('Maximum length of field',
         attribute=True, default=None)
     placeholder = twc.Param('Placeholder text (HTML5 only)',


### PR DESCRIPTION
This lets developers set `required` on the widget, making it more
similar in look and field to other input fields.
